### PR TITLE
wip: add images for contrail 5.0 on top of tungsten images

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,5 +5,7 @@
 let
   tools = import ./tools-overlay.nix;
   contrail = import ./contrail-overlay.nix;
+  pkgs = import nixpkgs { overlays = [ tools contrail ]; };
+  dockerImages = pkgs.callPackages ./pkgs/docker-images/default.nix { };
 
-in import nixpkgs { overlays = [ tools contrail ]; }
+in pkgs // { inherit dockerImages; }

--- a/pkgs/docker-images/default.nix
+++ b/pkgs/docker-images/default.nix
@@ -1,0 +1,50 @@
+{ pkgs, runCommand, dockerTools, contrail50 }:
+
+let
+  tungstenApi = dockerTools.pullImage {
+    imageName = "docker.io/opencontrailnightly/contrail-controller-config-api";
+    imageDigest = "sha256:7ebb285df2fdd512f6b885b772e6b2383ad1f23488d6a767f8bb21e55239fe62";
+    finalImageTag = "latest";
+    sha256 = "1qpw5vdvga3qd66rzdfsdw3wc51jf7hd9k16l41yphqrwc2ng75h";
+  };
+
+  tungstenSchema = dockerTools.pullImage {
+    imageName = "docker.io/opencontrailnightly/contrail-controller-config-schema";
+    imageDigest = "sha256:b6bc624a05de7d554df37096431f1ea0ea2086368e9f96fbdf1868f5eeb53a16";
+    finalImageTag = "latest";
+    sha256 = "06kz45wfgnyzi717dv79im263pl5pwpxklangqd3a6hzh4xd7g8p";
+  };
+  
+  # This is because symlinked directory in the parent image are not
+  # supported by nixpkgs.dockerTools.buildImage:/
+  # See https://github.com/NixOS/nixpkgs/issues/57073
+  toUsrBin = drv: runCommand "${drv.name}-to-usr-bin" {} ''
+    mkdir -p $out/usr/bin/
+    for i in $(ls ${drv}/bin/); do
+      ln -s ${drv}/bin/$i $out/usr/bin/$i
+    done
+  '';
+
+in {
+  contrailApi = dockerTools.buildImage {
+    name = "contrail-api";
+    tag = "r5.0";
+    fromImage = tungstenApi;
+    contents = toUsrBin contrail50.apiServer;
+    config = {
+      Entrypoint = [ "/entrypoint.sh" ];
+    };
+  };
+  contrailSchema = dockerTools.buildImage {
+    name = "contrail-schema";
+    tag = "r5.0";
+    fromImage = tungstenSchema;
+    contents = toUsrBin contrail50.schemaTransformer;
+    config = {
+      Entrypoint = [ "/entrypoint.sh" ];
+    };
+  };
+
+  # TODO: Add all other images. Since binaries already exist, it's a
+  # trivial task.
+}


### PR DESCRIPTION
Tungsten Docker images contain 700 lines of shell scripts used to
create configuration file in the entry point by using environment
variables. We don't want to reimplement all of this logic so we just
use their images as base image and we replace their binary by Nix
binaries.