### PR TITLE
Add webui component

### DIFF
--- a/contrail-overlay.nix
+++ b/contrail-overlay.nix
@@ -95,6 +95,7 @@ let
 
     lib = {
       fetchCentosKernel = callPackage ./pkgs/fetch-centos-kernel {};
+      buildWebuiDeps = callPackage ./pkgs/build-webui-deps.nix {};
 
       # we switch to gcc 4.9 because gcc 5 is not supported before kernel 3.18
       buildVrouter = callPackage ./pkgs/vrouter.nix { stdenv = stdenv_gcc49; };
@@ -155,6 +156,7 @@ let
 
     # deps
     deps = {
+      nodejs-4_x = callPackage ./pkgs/nodejs.nix { };
       cassandraCppDriver = callPackage ./pkgs/cassandra-cpp-driver.nix { stdenv = stdenv_gcc6; };
       libgrok = callPackage ./pkgs/libgrok.nix { };
       log4cplus = callPackage ./pkgs/log4cplus.nix { stdenv = stdenv_gcc5; };
@@ -253,9 +255,13 @@ in rec {
     };
   });
 
-  contrail50 = contrail41.overrideScope' (lself: lsuper: {
+  contrail50 = contrail41.overrideScope' (lself: lsuper: rec {
     contrailVersion = "5.0";
     contrailSources = callPackage ./sources-R5.0.nix { };
+    webui = callPackages ./pkgs/webui.nix { sources = contrailSources; inherit (lsuper) deps; };
+    test = lsuper.test // {
+      webui = callPackages ./test/webui.nix { contrailPkgs = lself; };
+    };
     contrailThirdPartyCache = lsuper.contrailThirdPartyCache.overrideAttrs(oldAttrs:
       { outputHash = "0h39vwdsi4b0xi4pcqnmfkfkcldf52bby3rnnbz6flmcapb5pxfd"; });
   });

--- a/modules/configuration/R5.0/webui.nix
+++ b/modules/configuration/R5.0/webui.nix
@@ -1,0 +1,382 @@
+{ pkgs, cfg, contrailPkgs }:
+
+pkgs.writeTextFile {
+  name = "contrail-webui.conf";
+  text = ''
+var config = {};
+
+config.orchestration = {};
+/****************************************************************************
+ * Specify Orchestration Model
+ * Available models are:
+ *  - openstack
+ *  - cloudstack
+ * If you do not want to specify any model, set it to "none"
+ *
+ *****************************************************************************/
+config.orchestration.Manager = "none";
+
+/****************************************************************************
+ * This boolean flag indicates to communicate with Orchestration
+ * modules(networkManager, imageManager, computeManager,
+ * storageManager), should the webServer communicate using the
+ * ip/port/authProtocol/apiVersion as specified in this file, or as returned
+ * from auth catalog list.
+ * Note: config.identityManager is not controlled by this boolean
+ * flag.
+ *
+ * true  - These values should be taken from this config
+ *         file.
+ * false - These values should be taken from auth catalog list
+ *
+ * Default: false
+ *****************************************************************************/
+config.orchestrationModuleEndPointFromConfig = true;
+
+/****************************************************************************
+ * This boolean flag indicates to communicate with contrail services Api Server
+ * and Analytics Server, should the webServer communicate using the
+ * ip/port/authProtocol as specified in this file, or as returned  from auth
+ * catalog list.
+ *
+ * true  - These values should be taken from this config
+ *         file.
+ * false - These values should be taken from auth catalog list
+ *
+ * Note: If this flag is set as false, we must have two services ApiServer and
+ * OpServer, variables as defined in config.endpoints to be provisioned in
+ * keystone
+ *
+ * Default: true
+ ****************************************************************************/
+config.contrailEndPointFromConfig = true;
+
+/****************************************************************************
+ * This boolean flag specifies wheather region list should be taken from config
+ * file or from keystone endpoint
+ * true  - If set as true, then keystone endpoint is taken from
+ *         config.regions
+ * false - If set as false, then keystone endpoint is taken from
+ *         config.identityManager
+ *
+ ****************************************************************************/
+config.regionsFromConfig = false;
+
+/****************************************************************************
+ * Below are the configs for Api Server and analytics Service type & name as
+ * provisioned in keystone
+ *
+ * apiServiceType - Service Type for apiServer, default value is apiServer
+ * opServiceType  - Service Type for analytics, default value is opServer
+ *
+ * Note: If there are multiple api server or analytices nodes in a specific
+ *       region, then provision service type/name as ApiServer0, ApiServer1,
+ *       ApiServer2 etc, similarly for analytics node: OpServer0, OpServer1,
+ *       OpServer2 etc.
+ *
+ ****************************************************************************/
+config.endpoints = {};
+config.endpoints.apiServiceType = "ApiServer";
+config.endpoints.opServiceType = "OpServer";
+
+/****************************************************************************
+ * Mapping to region name with keystone endpoint
+ *
+ * For example:
+ * config.regions.RegionOne = "http://10.0.1.4/identity";
+ * config.regions.RegionTwo = "http://nodeIp:5000/v3";
+ *
+ ****************************************************************************/
+config.regions = {};
+config.regions.RegionOne = "http://10.0.1.4/identity";
+
+/****************************************************************************
+ * This boolean flag indicates if orchestrationModuleEndPointFromConfig or
+ * contrailEndPointFromConfig is set as false,
+ * then to take IP/Port/Protocol/Version information from auth catalog,
+ * should publicURL OR internalURL will be used.
+ *
+ * true  - publicURL in endpoint will be used to retrieve IP/Port/Protocol/
+ *         Version information
+ * false - internalURL in endpoint will be used to retrieve
+ *         IP/Port/Protocol/Version information
+ *
+ * NOTE: if config.orchestrationModuleEndPointFromConfig is set as true, then
+ *       this flag does not have any effect on orchestration modules.
+ *       if config.contrailEndPointFromConfig is set as true, then this flag
+ *       does not have effect on contrail modules as defined in config.endpoints
+ *
+ *****************************************************************************/
+config.serviceEndPointTakePublicURL = true;
+
+/****************************************************************************
+ * Below are the config options for all Orchestration Modules below:
+ *  - networkManager
+ *  - imageManager
+ *  - computeManager
+ *  - identityManager
+ *  - storageManager
+ *  - cnfg
+ *  - analytics
+ *
+ * Options:
+ * ip:
+ *      IP to connect to for this Server.
+ * port:
+ *      Port to connect to for this server
+ * authProtocol:
+ *      Specify authProtocol either "http" or "https"
+ * apiVersion:
+ *      REST API Version for this server to connect to.
+ *      Specify a list of Versions in array notation.
+ *      Below are the supported list of apiVersion for the modules as of now:
+ *      imageManager    -   ["v1", "v2"]
+ *      computeManager  -   ["v1.1", "v2"]
+ *      identityManager -   ["v2.0"]
+ *      storageManager  -   ["v1"]
+ *
+ *      Not applicable for cnfg/analytics as of now
+ * strictSSL:
+ *      If true, requires certificates to be valid
+ * ca:
+ *      An authority certificate to check the remote host against,
+ *      if you do not want to specify then use ""
+ *****************************************************************************/
+config.networkManager = {};
+config.networkManager.ip = "127.0.0.1";
+config.networkManager.port = "9696"
+config.networkManager.authProtocol = "http";
+config.networkManager.apiVersion = [];
+config.networkManager.strictSSL = false;
+config.networkManager.ca = "";
+
+config.imageManager = {};
+config.imageManager.ip = "127.0.0.1";
+config.imageManager.port = "9292";
+config.imageManager.authProtocol = "http";
+config.imageManager.apiVersion = ["v1", "v2"];
+config.imageManager.strictSSL = false;
+config.imageManager.ca = "";
+
+config.computeManager = {};
+config.computeManager.ip = "127.0.0.1";
+config.computeManager.port = "8774";
+config.computeManager.authProtocol = "http";
+config.computeManager.apiVersion = ["v1.1", "v2"];
+config.computeManager.strictSSL = false;
+config.computeManager.ca = "";
+
+config.identityManager = {};
+config.identityManager.ip = "10.0.1.4";
+config.identityManager.port = "80";
+config.identityManager.authProtocol = "http";
+/******************************************************************************
+ * Note: config.identityManager.apiVersion = ["v3"];
+ * config.orchestrationModuleEndPointFromConfig. If specified apiVersion here,
+ * then these API versions will be used while using REST API to identityManager.
+ * If want to use with default apiVersion(v2.0), then can specify it as
+ * empty array.
+ ******************************************************************************/
+config.identityManager.apiVersion = ["v3"];
+config.identityManager.strictSSL = false;
+config.identityManager.ca = "";
+config.identityManager.urlPrefix = "/identity";
+
+config.storageManager = {};
+config.storageManager.ip = "127.0.0.1";
+config.storageManager.port = "8776";
+config.storageManager.authProtocol = "http";
+config.storageManager.apiVersion = ["v1"];
+config.storageManager.strictSSL = false;
+config.storageManager.ca = "";
+
+// VNConfig API server and port.
+config.cnfg = {};
+config.cnfg.server_ip = ["127.0.0.1"];
+config.cnfg.server_port = "8082";
+config.cnfg.authProtocol = "http";
+config.cnfg.strictSSL = false;
+config.cnfg.ca = "";
+config.cnfg.statusURL = "/global-system-configs";
+
+// Analytics API server and port.
+config.analytics = {};
+config.analytics.server_ip = ["127.0.0.1"];
+config.analytics.server_port = "8081";
+config.analytics.authProtocol = "http";
+config.analytics.strictSSL = false;
+config.analytics.ca = "";
+config.analytics.statusURL = "/analytics/uves/bgp-peers";
+
+//DNS API Server and port.
+/* Please note: being introspect port, SSL options for dns should come from
+   config.introspect.ssl configuration
+ */
+config.dns = {};
+config.dns.server_ip = ["127.0.0.1"];
+config.dns.server_port = "8092";
+config.dns.statusURL = "/Snh_PageReq?x=AllEntries%20VdnsServersReq";
+
+// vcenter related parameters
+config.vcenter = {};
+config.vcenter.server_ip = "127.0.0.1";         //vCenter IP
+config.vcenter.server_port = "443";             //Port
+config.vcenter.authProtocol = "https";          //http or https
+config.vcenter.datacenter = "vcenter";          //datacenter name
+config.vcenter.dvsswitch = "vswitch";           //dvsswitch name
+config.vcenter.strictSSL = false;               //Validate the certificate or ignore
+config.vcenter.ca = "";                         //specify the certificate key file
+config.vcenter.wsdl = "${contrailPkgs.webui.webCore}/webroot/js/vim.wsdl";
+
+/*****************************************************************************
+ * The below configurations descibe the SSL options for connecting to different
+ * introspect port.
+ *
+ * enabled:
+ *      Boolean flag to enable or disable ssl while connecting to different
+ *      introspect port
+ * key:
+ *      Private key to use for SSL
+ * cert:
+ *      Public x509 certificate to use
+ * ca:
+ *      A string, Buffer or array of strings or Buffers of trusted certificates
+ *      in PEM format. These are used to authorize connections.
+ * strictSSL:
+ *      If true, the server certificate is verified against the list of
+ *      supplied CAs
+ *****************************************************************************/
+config.introspect = {};
+config.introspect.ssl = {};
+config.introspect.ssl.enabled = false;
+config.introspect.ssl.key = "";
+config.introspect.ssl.cert = "";
+config.introspect.ssl.ca = "";
+config.introspect.ssl.strictSSL = false;
+
+/* Job Server */
+config.jobServer = {};
+config.jobServer.server_ip = "127.0.0.1";
+config.jobServer.server_port = "3000";
+
+/* Upload/Download Directory */
+config.files = {};
+config.files.download_path = "/tmp";
+
+/* Cassandra Server */
+config.cassandra = {};
+config.cassandra.server_ips = ["127.0.0.1"];
+config.cassandra.server_port = "9042";
+config.cassandra.enable_edit = false;
+
+/* KUE Job Scheduler */
+config.kue = {};
+config.kue.ui_port = "3002"
+
+/* IP List to listen on */
+config.webui_addresses = ["0.0.0.0"];
+
+/* Is insecure access to WebUI? 
+ * If set as false, then all http request will be redirected
+ * to https, if set true, then no https request will be processed, but only http
+ * request
+ */
+config.insecure_access = false;
+
+// HTTP port for NodeJS Server.
+config.http_port = "8080";
+
+// HTTPS port for NodeJS Server.
+config.https_port = "8143";
+
+// Activate/Deactivate Login.
+config.require_auth = false;
+
+/* Number of node worker processes for cluster. */
+config.node_worker_count = 1;
+
+/* Number of Parallel Active Jobs with same type */
+config.maxActiveJobs = 10;
+
+/* Redis DB index for Web-UI */
+config.redisDBIndex = 3;
+
+/* Retry time for reading servers list recursively */
+config.CONTRAIL_SERVICE_RETRY_TIME = 300000; //5 minutes
+
+/* WebUI Redis Server */
+config.redis_server_port = "6379";
+config.redis_server_ip = "127.0.0.1";
+config.redis_dump_file = "/var/lib/redis/dump-webui.rdb";
+config.redis_password = "";
+
+/* Logo File: Use complete path of logo file location */
+config.logo_file = "${contrailPkgs.webui.webCore}/webroot/img/opencontrail-logo.png";
+
+/* Favicon File: Use complete path of favicon file location */
+config.favicon_file = "${contrailPkgs.webui.webCore}/webroot/img/opencontrail-favicon.ico";
+
+config.featurePkg = {};
+/* Add new feature Package Config details below */
+config.featurePkg.webController = {};
+config.featurePkg.webController.path = "${contrailPkgs.webui.webController}";
+config.featurePkg.webController.enable = true;
+
+/* Enable/disable Stat Query Links in Sidebar*/
+config.qe = {};
+config.qe.enable_stat_queries = false;
+
+/* Configure level of logs, supported log levels are:
+ debug, info, notice, warning, error, crit, alert, emerg
+ */
+config.logs = {};
+config.logs.level = "debug";
+
+/******************************************************************************
+ * Boolean flag getDomainProjectsFromApiServer indicates wheather the project
+ * list should come from API Server or Identity Manager.
+ * If Set
+ *      - true, then project list will come from API Server
+ *      - false, then project list will come from Identity Manager
+ * Default: false
+ *
+ ******************************************************************************/
+config.getDomainProjectsFromApiServer = false;
+/*****************************************************************************
+ * Boolean flag L2_enable indicates the default forwarding-mode of a network.
+ * Allowed values : true / false
+ * Set this flag to true if all the networks are to be L2 networks,
+ * set to false otherwise.
+ *****************************************************************************/
+config.network = {};
+config.network.L2_enable = false;
+
+/******************************************************************************
+ * Boolean flag getDomainsFromApiServer indicates wheather the domain
+ * list should come from API Server or Identity Manager.
+ * If Set
+ *      - true, then domain list will come from API Server
+ *      - false, then domain list will come from Identity Manager
+ * Default: true
+ * NOTE: if config.identityManager.apiVersion = ["v3"];
+ *       does not have any effect, in that case the domain list is retrieved
+ *       from API Server.
+ *
+ *****************************************************************************/
+config.getDomainsFromApiServer = true;
+
+config.jsonSchemaPath = "${contrailPkgs.webui.webCore}/src/serverroot/configJsonSchemas";
+config.connectedAppsInfo = {};
+//This is global flag which enables links (display links in footer)
+// to all the connectedApps mentioned, however we can
+// override this by using enable flag (like config.connectedAppsInfo.AppFormix.enable)
+// in the app object
+config.connectedAppsInfo.enable = false;
+config.connectedAppsInfo.AppFormix = {};
+config.connectedAppsInfo.AppFormix.url = "";
+config.connectedAppsInfo.AppFormix.enable = false;
+
+// Export this as a module.
+module.exports = config;
+  '';
+}

--- a/modules/webui.nix
+++ b/modules/webui.nix
@@ -4,126 +4,7 @@ with lib;
 
 let
   cfg = config.contrail.webui;
-  web-server = pkgs.writeTextFile {
-    name = "contrail-web-server.js";
-    text = ''
-      var config = {};
-      config.staticAuth = [
-        {"username": "admin", "password": "admin"}
-      ];
-      config.multi_tenancy = {};
-      config.multi_tenancy.enabled = false;
-      config.orchestration = {};
-      config.orchestration.Manager = 'none';
-      config.serviceEndPointFromConfig = true;
-      config.endpoints = {};
-      config.endpoints.apiServiceType = 'ApiServer';
-      config.endpoints.opServiceType = 'OpServer';
-      config.regionsFromConfig = true;
-      config.regions = {};
-      config.regions.RegionOne = 'http://127.0.0.1:5000/v2.0';
-      config.serviceEndPointTakePublicURL = true;
-      config.networkManager = {};
-      config.networkManager.ip = '127.0.0.1';
-      config.networkManager.port = '9696'
-      config.networkManager.authProtocol = 'http';
-      config.networkManager.apiVersion = [];
-      config.networkManager.strictSSL = false;
-      config.networkManager.ca = "";
-      config.imageManager = {};
-      config.imageManager.ip = '127.0.0.1';
-      config.imageManager.port = '9292';
-      config.imageManager.authProtocol = 'http';
-      config.imageManager.apiVersion = ['v1', 'v2'];
-      config.imageManager.strictSSL = false;
-      config.imageManager.ca = "";
-      config.computeManager = {};
-      config.computeManager.ip = '127.0.0.1';
-      config.computeManager.port = '8774';
-      config.computeManager.authProtocol = 'http';
-      config.computeManager.apiVersion = ['v1.1', 'v2'];
-      config.computeManager.strictSSL = false;
-      config.computeManager.ca = "";
-      config.identityManager = {};
-      config.identityManager.ip = '127.0.0.1';
-      config.identityManager.port = '5000';
-      config.identityManager.authProtocol = 'http';
-      config.identityManager.apiVersion = ['v2.0'];
-      config.identityManager.strictSSL = false;
-      config.identityManager.ca = "";
-      config.storageManager = {};
-      config.storageManager.ip = '127.0.0.1';
-      config.storageManager.port = '8776';
-      config.storageManager.authProtocol = 'http';
-      config.storageManager.apiVersion = ['v1'];
-      config.storageManager.strictSSL = false;
-      config.storageManager.ca = "";
-      config.cnfg = {};
-      config.cnfg.server_ip = '127.0.0.1';
-      config.cnfg.server_port = '8082';
-      config.cnfg.authProtocol = 'http';
-      config.cnfg.strictSSL = false;
-      config.cnfg.ca = "";
-      config.analytics = {};
-      config.analytics.server_ip = '127.0.0.1';
-      config.analytics.server_port = '8081';
-      config.analytics.authProtocol = 'http';
-      config.analytics.strictSSL = false;
-      config.analytics.ca = "";
-      config.vcenter = {};
-      config.vcenter.server_ip = '127.0.0.1';         //vCenter IP
-      config.vcenter.server_port = '443';             //Port
-      config.vcenter.authProtocol = 'https';          //http or https
-      config.vcenter.datacenter = 'vcenter';          //datacenter name
-      config.vcenter.dvsswitch = 'vswitch';           //dvsswitch name
-      config.vcenter.strictSSL = false;               //Validate the certificate or ignore
-      config.vcenter.ca = "";                         //specify the certificate key file
-      config.vcenter.wsdl = '${contrailPkgs.webCore}/webroot/js/vim.wsdl';
-      config.discoveryService = {};
-      config.discoveryService.server_port = '5998';
-      config.discoveryService.enable = true;
-      config.jobServer = {};
-      config.jobServer.server_ip = '127.0.0.1';
-      config.jobServer.server_port = '3000';
-      config.files = {};
-      config.files.download_path = '/tmp';
-      config.cassandra = {};
-      config.cassandra.server_ips = ['127.0.0.1'];
-      config.cassandra.server_port = '9042';
-      config.cassandra.enable_edit = false;
-      config.kue = {};
-      config.kue.ui_port = '3002'
-      config.webui_addresses = ['0.0.0.0'];
-      config.insecure_access = false;
-      config.http_port = '8080';
-      config.https_port = '8143';
-      config.require_auth = false;
-      config.node_worker_count = 1;
-      config.maxActiveJobs = 10;
-      config.redisDBIndex = 3;
-      config.redis_server_port = '6379';
-      config.redis_server_ip = '127.0.0.1';
-      config.redis_dump_file = '/var/lib/redis/dump-webui.rdb';
-      config.redis_password = "";
-      config.logo_file = '${contrailPkgs.webCore}/webroot/img/opencontrail-logo.png';
-      config.favicon_file = '${contrailPkgs.webCore}/webroot/img/opencontrail-favicon.ico';
-      config.featurePkg = {};
-      config.featurePkg.webController = {};
-      config.featurePkg.webController.path = '${contrailPkgs.webController}';
-      config.featurePkg.webController.enable = true;
-      config.qe = {};
-      config.qe.enable_stat_queries = false;
-      config.logs = {};
-      config.logs.level = 'debug';
-      config.getDomainProjectsFromApiServer = false;
-      config.network = {};
-      config.network.L2_enable = false;
-      config.getDomainsFromApiServer = true;
-      config.jsonSchemaPath = "${contrailPkgs.webCore}/src/serverroot/configJsonSchemas";
-      module.exports = config;
-    '';
-  };
-
+  confFile = import (./configuration + "/R${contrailPkgs.contrailVersion}/webui.nix") { inherit pkgs cfg contrailPkgs; };
 in {
   options = {
     contrail.webui = {
@@ -131,24 +12,31 @@ in {
         type = types.bool;
         default = false;
       };
+      configFile = mkOption {
+        type = types.path;
+        description = "contrail webui configuration file";
+        default = confFile;
+      };
     };
   };
   config = mkIf cfg.enable {
-    systemd.services.contrailJobServer = {
+    systemd.services.contrail-job-server = {
       wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" "contrailDiscovery.service" ];
-      serviceConfig.WorkingDirectory = "${contrailPkgs.webCore}";
+      requires = [ "contrail-analytics-api.service" "cassandra.service" "contrail-api.service" ];
+      after = [ "network.target" "contrail-analytics-api.service" "cassandra.service" "contrail-api.service" ];
+      serviceConfig.WorkingDirectory = "${contrailPkgs.webui.webCore}";
       preStart = ''
-        cp ${web-server} /tmp/contrail-web-core-config.js
+        cp ${cfg.configFile} /tmp/contrail-web-core-config.js
       '';
-      script = "${pkgs.nodejs-4_x}/bin/node ${contrailPkgs.webCore}/jobServerStart.js";
+      script = "${contrailPkgs.deps.nodejs-4_x}/bin/node ${contrailPkgs.webui.webCore}/jobServerStart.js";
     };
 
-    systemd.services.contrailWebServer = {
+    systemd.services.contrail-web-server = {
       wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" "contrailJobServer.service" "contrailAnalyticsApi.service" ];
-      serviceConfig.WorkingDirectory = "${contrailPkgs.webCore}";
-      script = "${pkgs.nodejs-4_x}/bin/node ${contrailPkgs.webCore}/webServerStart.js";
+      requires = [ "contrailJobServer.service" "contrail-analytics-api.service" "cassandra.service" "contrail-api.service" ];
+      after = [ "contrailJobServer.service" "network.target" "contrail-analytics-api.service" "cassandra.service" "contrail-api.service" ];
+      serviceConfig.WorkingDirectory = "${contrailPkgs.webui.webCore}";
+      script = "${contrailPkgs.deps.nodejs-4_x}/bin/node ${contrailPkgs.webui.webCore}/webServerStart.js";
     };
   };
 }

--- a/pkgs/build-webui-deps.nix
+++ b/pkgs/build-webui-deps.nix
@@ -1,0 +1,106 @@
+{ pkgs
+, stdenv
+, deps
+, contrailSources
+}:
+
+let
+
+  inherit (pkgs) makeWrapper cacert unzip curl rsync;
+  inherit (deps) nodejs-4_x;
+
+  pythonWithXml = pkgs.python.withPackages (ps: with ps; [ lxml ]);
+
+  webui-fetcher = stdenv.mkDerivation {
+    name = "contrail-webui-fetch-packages";
+    src = contrailSources.webuiThirdParty;
+    unpackPhase = "cp $src/fetch_packages.py fetch_packages.py";
+    buildPhase = ":";
+    buildInputs = [ makeWrapper cacert pythonWithXml unzip curl nodejs-4_x ];
+    patchPhase = ''
+      # do not pollute /tmp
+      substituteInPlace fetch_packages.py --replace \
+        "_PACKAGE_CACHE='/tmp/cache/' + os.environ['USER'] + '/webui_third_party'" \
+        "_PACKAGE_CACHE=os.environ['PWD'] + '/cache/'"
+
+      # do not chdir to the CWD (which would be in the nix store
+      substituteInPlace fetch_packages.py --replace \
+        "os.chdir(os.path.dirname(os.path.realpath(__file__)))" \
+        ""
+
+      # do not remove cached files
+      substituteInPlace fetch_packages.py --replace \
+        "os.remove(ccfile)" \
+        "pass"
+
+      # do not ignore certificates when downloading
+      substituteInPlace fetch_packages.py --replace \
+        "subprocess.call(['wget', '--no-check-certificate', '-O', ccfile, url])" \
+        "subprocess.call(['curl', '-L', '-o', ccfile, url])"
+    '';
+    installPhase = ''
+      mkdir -p $out/bin
+      cp fetch_packages.py $out/bin/fetch_packages.py
+      chmod +x $out/bin/fetch_packages.py
+      wrapProgram $out/bin/fetch_packages.py  \
+        --prefix PATH : "${pkgs.lib.makeBinPath [pythonWithXml unzip curl nodejs-4_x ]}" \
+        --set SSL_CERT_FILE ${cacert}/etc/ssl/certs/ca-bundle.crt
+    '';
+  };
+
+  webui-deps-rev = "${contrailSources.webuiThirdParty.rev}";
+  webui-deps-file = "webui-deps-${webui-deps-rev}.tar.xz";
+  webui-deps-url = "https://storage.fr1.cloudwatt.com/v1/AUTH_e1cd9b90abb840798055d37b29f1a7d2/nixpkgs-tungsten-webui/${webui-deps-file}";
+
+  in
+
+  # --- A NOTE on the Impurity of the webui dependencies and its workaround ---
+  #
+  # -- The Problem --
+  #
+  # Unfortunately the way in which the webui project fetches its dependencies is
+  # completely non-deterministic in its output. This is mostly because of 2 things:
+  #
+  # 1. ancient npm version
+  # 2. no package.json / lock file but independent `npm install` calls
+  #
+  # Updating npm and thus node is non-trivial and webui uses a lot of severly outdated packages
+  # and also applies patches that inject contrail specific code in dependencies.
+  #
+  # -- The workaround --
+  #
+  # Since the deps required to build the webui cannot be put into a derivation the shell
+  # expression below is provided to create a tarball. This tarball is then uploaded to an
+  # object storage and is retrieved via `webui-thirdparty-deps` below.
+  #
+  # -- The workflow --
+  #
+  # If you need to update the webui using new sources you need to recreate the deps:
+  #
+  # $ nix-shell default.nix -A contrail50.lib.buildWebuiDeps
+  #
+  # This will create a `.tar.xz` in $PWD along with its sha256. Update the hash of
+  # `webui-thirdparty-deps` below and upload the file to the object storage.
+
+  pkgs.mkShell rec {
+    buildInputs = [ webui-fetcher rsync nodejs-4_x contrailSources.webuiThirdParty ];
+    shellHook = ''
+      OUT=$PWD/${webui-deps-file}
+      BUILD_DIR=$(mktemp -d)
+      cp -R ${contrailSources.webuiThirdParty}/* $BUILD_DIR
+      pushd $BUILD_DIR>/dev/null
+
+      mkdir .home
+      export HOME=$(readlink -f .home)
+      fetch_packages.py -f ./packages.xml
+
+      patchShebangs ./node_modules
+      tar cfJ $OUT --transform 's,^\.,webui-thirdparty-deps,' .
+
+      popd >/dev/null
+      echo -e "\n\n"
+      ls $OUT
+      nix-prefetch-url --type sha256 --unpack file://$OUT
+      exit 0
+    '';
+  }

--- a/pkgs/nodejs.nix
+++ b/pkgs/nodejs.nix
@@ -1,0 +1,11 @@
+{ pkgs, fetchurl }:
+
+pkgs.nodejs-6_x.overrideAttrs (old: rec {
+  name = "nodejs-4.8.7";
+  version = "4.8.7";
+  sha256 = "1y21wq092d3gmccm2zldbflbbbx7a71wi9l0bpkxvzmgws69liq3";
+  src = fetchurl {
+    url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.xz";
+    inherit sha256;
+  };
+})

--- a/sources-R5.0.nix
+++ b/sources-R5.0.nix
@@ -76,4 +76,28 @@
     rev = "a0ed6e3bcbf80826a6bc64dd2158d5a2c2f7c75f";
     sha256 = "15d03snx1iv1r4r2zk8zcyq15gw4mq3w5dy1ja12z0gwrbhpyid7";
   };
+  # Head of branch R5.0 of repository github.com/Juniper/contrail-webui-third-party at 2019-03-25 16:23:49
+  webuiThirdParty = pkgs.fetchFromGitHub {
+    name = "webuiThirdParty";
+    owner = "Juniper";
+    repo = "contrail-webui-third-party";
+    rev = "10d5493cc093e0b67e80af7e5b16b69f63e600ab";
+    sha256 = "06abxqlgcix9z1wisy323g7nq49faz0m82k61j7345ml543xp0n2";
+  };
+  # Head of branch R5.0 of repository github.com/Juniper/contrail-web-core at 2019-03-27 15:20:45
+  webCore = pkgs.fetchFromGitHub {
+    name = "webCore";
+    owner = "Juniper";
+    repo = "contrail-web-core";
+    rev = "5d88c9b5cd6460b6814222d40cded3d5b8115c9c";
+    sha256 = "100sl2jjvxa5p92qhhh5ysk7820p08nc1xczwwgm5nl7rdm2gi9p";
+  };
+   # Head of branch R5.0 of repository github.com/Juniper/contrail-web-controller at 2019-03-27 15:30:02
+  webController = pkgs.fetchFromGitHub {
+    name = "webController";
+    owner = "Juniper";
+    repo = "contrail-web-controller";
+    rev = "020de4532c0059f2c32ead4aa58db374cc761c97";
+    sha256 = "0z1na6pm7jbwvkmixlx4x2qig2z8qzw00zpcp3182nfj8wgy5lq1";
+  };
 }

--- a/tools/sources-R5.0.lst
+++ b/tools/sources-R5.0.lst
@@ -7,3 +7,6 @@ vrouter Juniper contrail-vrouter R5.0
 common Juniper contrail-common R5.0
 analytics Juniper contrail-analytics R5.0
 apiClient Juniper contrail-api-client R5.0
+webuiThirdParty Juniper contrail-webui-third-party R5.0
+webCore Juniper contrail-web-core R5.0
+webController Juniper contrail-web-controller R5.0


### PR DESCRIPTION
### Overview

The goal of this PR is to add the contrail webui. This consists of:

- a webui package (`./pkgs/webui.nix`)
- a webui test (`./test/webui.nix`)
- a webui module (`modules/webui.nix`)
- updates and additions to required sources

Most of this is based on work previously done by @eonpatapon on the webui but updated for contrail-50.

### Current Issues

- [x] `webui-thirdparty-deps` is a fixed-output-derivation but it seems impossible to make this reproducible because it makes use of `npm install` calls using ancient nodejs versions which are inherently non-deterministic. One possible/ugly workaround would be to build this separately somewhere and just reference/fetch the result.
- [x] `contrail-dns` is being used which triggers some error on the server stdout. I currently don't know if `contrail-dns` is mandatory for the webui to work or not. I'll have to try this on a devstack installation: *Update*: I tried it on a devstack installation. The ui works with the dns shut down
- [x] `keystone` is being called even when setting `config.orchestration.Manager` to `none`. Adding some `console.log` calls to the server has me thinking that the configuration is not being read properly or differs from any documentation that can be found online. Currently the server falls back to a default which is `openstack`. When I patch the default to be `none` instead the keystone connection atttempts are gone.
- [x] I can login to the ui but it is mostly just empty (even with the keystone patching described above). This may or may not be related to `contrail-dns` missing. There is also a javascript error on the client side which could be degrading the UI functionality.

### Things to try

- [x] Shut down `contrail-dns` and see if the ui works -- *done, it works without dns*
- [x] Run this webui on the devstack machine 


### Trying it out
```
nix-build -A contrail50.test.webui.driver
QEMU_NET_OPTS="hostfwd=tcp::8080-:8080,hostfwd=tcp::8143-:8143,hostfwd=tcp::2222-:22" result/bin/nixos-run-vms
```

## The Big Ugly webui-thirdparty Wart

Unfortunately the way in which the dependencies for the webui are being fetched just really isn't deterministic (mostly thanks to the combination of the messy implementation and the use of ancient `npm` / `node`)

The only way to work around this has been to pre-build the dependencies (in a nix-shell) and store them in some object storage to be retrieved by the actual webui derivations. This is *ugly* but currently the only way to handle this.