### PR TITLE
Use builtins.fetchTarball for bootstraping

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,4 @@
-{ fetched ? import ./nixpkgs-fetch.nix {}
-, nixpkgs ? fetched.pkgs
-}:
+{ nixpkgs ? import ./nixpkgs-fetch.nix {} }:
 
 let
   tools = import ./tools-overlay.nix;

--- a/nixpkgs-fetch.nix
+++ b/nixpkgs-fetch.nix
@@ -1,11 +1,11 @@
 { nixpkgs ? <nixpkgs> }:
 
-let bootstrap_pkgs = import nixpkgs {};
-in {
-  pkgs = bootstrap_pkgs.fetchFromGitHub {
-    owner = "NixOS";
-    repo = "nixpkgs";
-    # Belong to the branch release-18.09
+let
     rev = "7e88992a8c7b2de0bcb89182d8686b27bd93e46a";
-    sha256 = "1f6lf4addczi81hchqbzjlhrsmkrj575dmdjdhyl0jkm7ypy2lgk";};
-  }
+    sha256 = "1f6lf4addczi81hchqbzjlhrsmkrj575dmdjdhyl0jkm7ypy2lgk";
+in
+  builtins.fetchTarball {
+    name = "pinned-18.09-nixpkgs";
+    url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+    inherit sha256;
+}


### PR DESCRIPTION
This introduces the use of builtins.fetchTarball for bootstrapping in
nixpkgs-fetch.nix. The previous code relied on the system provided
<nixpkgs> for bootstrapping.

This also works as a drive-by-fix for the occasionally occurring error
message around a missing `.drv` when trying to evaluate queries. Also
the output now has "pinned-18.09-nixpkgs" which can be useful in error
scenarios/debugging.