### PR TITLE
Add hydra-eval script

### DIFF
--- a/pkgs/hydra-eval-nixpkgs-tungsten-jobs.nix
+++ b/pkgs/hydra-eval-nixpkgs-tungsten-jobs.nix
@@ -1,0 +1,20 @@
+{ pkgs }:
+
+let
+  inherit (pkgs) writeScriptBin nix hydra bash;
+in
+  writeScriptBin "hydra-eval-nixpkgs-tungsten-jobs" ''
+  #!${bash}/bin/bash
+
+  # NIXPKGS_BOOTSTRAP is only used to fetch fixed output derivations,
+  # so we don't care about it's version since the sha of all
+  # derivations it builds are checked.
+    echo "fetching bootstrap nixpkgs..."
+    NIXPKGS_BOOTSTRAP=$(${nix}/bin/nix-instantiate --eval -E 'builtins.fetchTarball { url=https://github.com/NixOS/nixpkgs/archive/acd89daabcb47cb882bc72ffc2d01281ed1fecb8.tar.gz; }' | tr -d '"')
+
+    echo "add to store nixpkgs-tungsten..."
+    TUNGSTEN=$(${nix}/bin/nix add-to-store $PWD)
+
+    echo "running hydra-eval-jobs..."
+    ${hydra}/bin/hydra-eval-jobs '<tungsten/jobset.nix>' -I tungsten=$TUNGSTEN -I nixpkgs=$NIXPKGS_BOOTSTRAP
+  ''

--- a/shell.nix
+++ b/shell.nix
@@ -9,5 +9,6 @@ pkgs.mkShell {
     gremlinConsole
     gremlinServer
     gremlinFsck
+    hydraEval
   ];
 }

--- a/tools-overlay.nix
+++ b/tools-overlay.nix
@@ -9,4 +9,5 @@ in {
   gremlinServer = callPackage ./tools/gremlin-server { };
   gremlinFsck = callPackage ./tools/contrail-gremlin/fsck.nix { };
   tungstenPrometheusExporter = callPackage ./tools/tungsten-prometheus-exporter { };
+  hydraEval = callPackage ./pkgs/hydra-eval-nixpkgs-tungsten-jobs.nix {};
 }


### PR DESCRIPTION
This adds a hydra-eval script to allow for local evaluation identical to
the one done by hydra.

In order to use it run `nix-shell` and execute
`hydra-eval-nixpkgs-tungsten-jobs`.