### PR TITLE
Allow overriding the default nix install script url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: generic
 before_install:
     - sudo install -d -m755 -o $(id -u) -g $(id -g) /nix
 script:
-    - ./please init
+    - NIX_INSTALL_URL=https://nixos.org/releases/nix/nix-2.2.1/install ./please init
     - ./please doctor
     - ./please list
     - ./please list | grep contrail

--- a/please
+++ b/please
@@ -4,6 +4,7 @@
 JOBSET=./jobset.nix
 GET_ATTRS=./scripts/get-attrs.nix
 BASH_COMPL_SCRIPT=./scripts/please.complete.bash.sh
+NIX_INSTALL_URL="${NIX_INSTALL_URL:-https://nixos.org/nix/install}"
 
 
 log() {
@@ -127,7 +128,7 @@ init() {
     else
         log "Looks like nix is not installed yet"
         log "Running 'curl https://nixos.org/nix/install | sh'"
-        curl https://nixos.org/nix/install | sh
+        curl "$NIX_INSTALL_URL" | sh
         _sourceNix
     fi
 


### PR DESCRIPTION
- This allows for overriding of the nix install script by setting `NIX_INSTALL_URL`
- This PR also uses this feature to pick Nix 2.2.1 instead which might be more stable during installation