### PR TITLE
completions: do not fail without nix-instantiate

### DIFF
--- a/scripts/please.complete.bash.sh
+++ b/scripts/please.complete.bash.sh
@@ -20,6 +20,12 @@ _please_completions()
         return
     fi
 
+    # Without nix-instantiate we cannot retrieve any
+    # suggestions
+    if ! type nix-instantiate >/dev/null 2>&1; then
+        return
+    fi
+
     case "$prev" in
         uninstall|install|build|shell)
             COMPREPLY=($(compgen -W "$(_get_attrs)" "$cur"))


### PR DESCRIPTION
if nix-instantiate is not available only the ./please main
commands can be completed but no arguments. Just return
if `nix-instantiate` is not in PATH

Fixes #30 