### PR TITLE
Source nix in the completion script

### DIFF
--- a/scripts/please.complete.bash.sh
+++ b/scripts/please.complete.bash.sh
@@ -1,4 +1,7 @@
 GET_ATTRS=./scripts/get-attrs.nix
+NIX_SH="$HOME/.nix-profile/etc/profile.d/nix.sh"
+
+test -f "$NIX_SH" && source "$NIX_SH"
 
 _get_attrs()
 {


### PR DESCRIPTION
Ensure that the completions work if nix is available but perhaps not sourced.

The Nix installer *tries* to do something sensible and add a `source` command to
`.profile` or `.bashrc` depending on certain hints but this isn't reliable and the safest way
for `please` is to just source it itself.